### PR TITLE
Fix #38

### DIFF
--- a/example/CodeInterpreter/Program.cs
+++ b/example/CodeInterpreter/Program.cs
@@ -38,12 +38,12 @@ var agent = new OpenAIChatAgent(
     .RegisterMessageConnector();
 
 var codeInterpreter = new Workflow(agent, kernel);
-var engine = StepWiseEngine.CreateFromInstance(codeInterpreter, maxConcurrency: 1);
+var engine = StepWiseEngine.CreateFromInstance(codeInterpreter);
 
 var task = "use python to switch my system to dark mode";
 StepVariable[] input = [StepVariable.Create("task", task)];
 
-await foreach (var stepRun in engine.ExecuteAsync(nameof(Workflow.GenerateReply), input))
+await foreach (var stepRun in engine.ExecuteAsync(nameof(Workflow.GenerateReply), input, maxConcurrency: 1))
 {
     Console.WriteLine(stepRun);
 

--- a/example/CodeInterpreter/Program.cs
+++ b/example/CodeInterpreter/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.Interactive;
 using Microsoft.Extensions.Logging;
 using OpenAI;
 using StepWise.Core;
+using StepWise.Core.Extension;
 
 var loggerFactory = LoggerFactory.Create(builder =>
 {
@@ -43,11 +44,11 @@ var engine = StepWiseEngine.CreateFromInstance(codeInterpreter);
 var task = "use python to switch my system to dark mode";
 StepVariable[] input = [StepVariable.Create("task", task)];
 
-await foreach (var stepRun in engine.ExecuteAsync(nameof(Workflow.GenerateReply), input, maxConcurrency: 1))
+await foreach (var stepRun in engine.ExecuteAsync(nameof(Workflow.GenerateReply), input, maxConcurrency: 1, stopStrategy: null))
 {
     Console.WriteLine(stepRun);
 
-    if (stepRun.Name == nameof(Workflow.GenerateReply) && stepRun.Status == StepType.Completed && stepRun.Variable?.As<string>() is string reply)
+    if (stepRun.Name == nameof(Workflow.GenerateReply) && stepRun.StepType == StepType.Completed && stepRun.Variable?.As<string>() is string reply)
     {
         Console.WriteLine($"Final Reply: {reply}");
         break;

--- a/example/CodeInterpreter/Program.cs
+++ b/example/CodeInterpreter/Program.cs
@@ -47,7 +47,7 @@ await foreach (var stepRun in engine.ExecuteAsync(nameof(Workflow.GenerateReply)
 {
     Console.WriteLine(stepRun);
 
-    if (stepRun.StepName == nameof(Workflow.GenerateReply) && stepRun.Status == StepStatus.Completed && stepRun.Result?.As<string>() is string reply)
+    if (stepRun.Name == nameof(Workflow.GenerateReply) && stepRun.Status == StepStatus.Completed && stepRun.Variable?.As<string>() is string reply)
     {
         Console.WriteLine($"Final Reply: {reply}");
         break;

--- a/example/CodeInterpreter/Program.cs
+++ b/example/CodeInterpreter/Program.cs
@@ -47,7 +47,7 @@ await foreach (var stepRun in engine.ExecuteAsync(nameof(Workflow.GenerateReply)
 {
     Console.WriteLine(stepRun);
 
-    if (stepRun.Name == nameof(Workflow.GenerateReply) && stepRun.Status == StepStatus.Completed && stepRun.Variable?.As<string>() is string reply)
+    if (stepRun.Name == nameof(Workflow.GenerateReply) && stepRun.Status == StepType.Completed && stepRun.Variable?.As<string>() is string reply)
     {
         Console.WriteLine($"Final Reply: {reply}");
         break;

--- a/example/GetWeather/Program.cs
+++ b/example/GetWeather/Program.cs
@@ -11,7 +11,7 @@ var loggerFactory = LoggerFactory.Create(builder =>
 });
 
 var getWeather = new Workflow();
-var workflowEngine = StepWiseEngine.CreateFromInstance(getWeather, maxConcurrency: 3, loggerFactory.CreateLogger<StepWiseEngine>());
+var workflowEngine = StepWiseEngine.CreateFromInstance(getWeather, loggerFactory.CreateLogger<StepWiseEngine>());
 
 StepVariable[] input =
 [

--- a/example/GetWeather/Program.cs
+++ b/example/GetWeather/Program.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using StepWise.Core;
+using StepWise.Core.Extension;
 
 var loggerFactory = LoggerFactory.Create(builder =>
 {
@@ -18,7 +19,7 @@ StepVariable[] input =
     StepVariable.Create("cities", new string[] { "Seattle", "Redmond" })
 ];
 
-await foreach (var stepRun in workflowEngine.ExecuteAsync(nameof(Workflow.GetWeatherAsync), input))
+await foreach (var stepRun in workflowEngine.ExecuteAsync(nameof(Workflow.GetWeatherAsync), input, stopStrategy: null))
 {
     if (stepRun.Name == nameof(Workflow.GetWeatherAsync) && stepRun.Variable?.As<Workflow.Weather[]>() is Workflow.Weather[] weathers)
     {

--- a/example/GetWeather/Program.cs
+++ b/example/GetWeather/Program.cs
@@ -20,7 +20,7 @@ StepVariable[] input =
 
 await foreach (var stepRun in workflowEngine.ExecuteAsync(nameof(Workflow.GetWeatherAsync), input))
 {
-    if (stepRun.StepName == nameof(Workflow.GetWeatherAsync) && stepRun.Result?.As<Workflow.Weather[]>() is Workflow.Weather[] weathers)
+    if (stepRun.Name == nameof(Workflow.GetWeatherAsync) && stepRun.Variable?.As<Workflow.Weather[]>() is Workflow.Weather[] weathers)
     {
         Console.WriteLine("Weather forecast:");
         foreach (var weather in weathers)

--- a/src/StepWise.Core/Extension/StepWiseEngineExtension.cs
+++ b/src/StepWise.Core/Extension/StepWiseEngineExtension.cs
@@ -41,9 +41,9 @@ public static class StepWiseEngineExtension
         maxSteps ??= int.MaxValue;
         await foreach (var stepResult in engine.ExecuteAsync(targetStepName, inputs, maxConcurrency, stopStrategy, ct))
         {
-            if (stepResult.Result != null && stepResult.StepName == targetStepName)
+            if (stepResult.Variable != null && stepResult.Name == targetStepName)
             {
-                return stepResult.Result.As<TResult>() ?? throw new Exception($"Step '{targetStepName}' did not return the expected result type.");
+                return stepResult.Variable.As<TResult>() ?? throw new Exception($"Step '{targetStepName}' did not return the expected result type.");
             }
         }
 
@@ -114,7 +114,7 @@ public static class StepWiseEngineExtension
             var step = targetStep;
             var stepInputs = inputs?.ToList() ?? new List<StepVariable>();
             var stopStrategy = new StopStrategyPipeline();
-            stopStrategy.AddStrategy(new MaxStepsStopStrategy(1));
+            //stopStrategy.AddStrategy(new MaxStepsStopStrategy(1));
             stopStrategy.AddStrategy(new EarlyStopStrategy(targetStepName));
 
             await foreach (var stepRun in engine.ExecuteStepsAsync([step], stepInputs, maxConcurrency, stopStrategy, ct))

--- a/src/StepWise.Core/IStepWiseEngine.cs
+++ b/src/StepWise.Core/IStepWiseEngine.cs
@@ -8,16 +8,6 @@ public interface IStepWiseEngine
     /// <summary>
     /// Execute the workflow until the stop strategy is satisfied or no further steps can be executed.
     /// </summary>
-    IAsyncEnumerable<StepRun> ExecuteAsync(
-        string? targetStep = null,
-        IEnumerable<StepVariable>? inputs = null,
-        int maxConcurrency = 1,
-        IStepWiseEngineStopStrategy? stopStrategy = null,
-        CancellationToken ct = default);
-
-    /// <summary>
-    /// Execute the workflow until the stop strategy is satisfied or no further steps can be executed.
-    /// </summary>
     IAsyncEnumerable<StepRun> ExecuteStepsAsync(
         IEnumerable<Step> steps,
         IEnumerable<StepVariable>? inputs = null,
@@ -82,7 +72,7 @@ public class MaxStepsStopStrategy : IStepWiseEngineStopStrategy
 
     public bool ShouldStop(StepRun[] stepResult)
     {
-        return stepResult.Where(x => x.Status == StepStatus.Variable || x.Status == StepStatus.Failed).Count() >= _maxSteps;
+        return stepResult.Where(x => x.StepType == StepType.Variable || x.StepType == StepType.Failed).Count() >= _maxSteps;
     }
 }
 

--- a/src/StepWise.Core/IStepWiseEngine.cs
+++ b/src/StepWise.Core/IStepWiseEngine.cs
@@ -11,8 +11,21 @@ public interface IStepWiseEngine
     IAsyncEnumerable<StepRun> ExecuteAsync(
         string? targetStep = null,
         IEnumerable<StepVariable>? inputs = null,
+        int maxConcurrency = 1,
         IStepWiseEngineStopStrategy? stopStrategy = null,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Execute the workflow until the stop strategy is satisfied or no further steps can be executed.
+    /// </summary>
+    IAsyncEnumerable<StepRun> ExecuteStepsAsync(
+        IEnumerable<Step> steps,
+        IEnumerable<StepVariable>? inputs = null,
+        int maxConcurrency = 1,
+        IStepWiseEngineStopStrategy? stopStrategy = null,
+        CancellationToken ct = default);
+
+    Workflow Workflow { get; }
 }
 
 public interface IStepWiseEngineStopStrategy

--- a/src/StepWise.Core/IStepWiseEngine.cs
+++ b/src/StepWise.Core/IStepWiseEngine.cs
@@ -82,7 +82,7 @@ public class MaxStepsStopStrategy : IStepWiseEngineStopStrategy
 
     public bool ShouldStop(StepRun[] stepResult)
     {
-        return stepResult.Where(x => x.Status == StepStatus.Completed || x.Status == StepStatus.Failed).Count() >= _maxSteps;
+        return stepResult.Where(x => x.Status == StepStatus.Variable || x.Status == StepStatus.Failed).Count() >= _maxSteps;
     }
 }
 
@@ -102,7 +102,7 @@ public class EarlyStopStrategy : IStepWiseEngineStopStrategy
 
     public bool ShouldStop(StepRun[] stepResult)
     {
-        return stepResult.Any(x => x.StepName == _targetStep && x.Result != null);
+        return stepResult.Any(x => x.Name == _targetStep && x.Variable != null);
     }
 }
 

--- a/src/StepWise.Core/Step.cs
+++ b/src/StepWise.Core/Step.cs
@@ -56,9 +56,13 @@ public class Step
     }
 
     public string Name { get; set; }
+
     public List<Parameter> InputParameters { get; set; }
+
     public Type OutputType { get; set; }
+
     public List<string> Dependencies { get; set; }
+
     public Delegate StepMethod { get; set; }
 
     public string Description { get; set; }

--- a/src/StepWise.Core/Step.cs
+++ b/src/StepWise.Core/Step.cs
@@ -182,6 +182,7 @@ public class StepVariable
 public enum StepStatus
 {
     Queue,
+    MissingInput,
     Running,
     Completed,
     Failed,
@@ -236,6 +237,16 @@ public class StepRun
         Dictionary<string, StepVariable>? inputs = null)
     {
         return new StepRun(step, generation, inputs ?? new Dictionary<string, StepVariable>());
+    }
+
+    public StepRun ToMissingInput()
+    {
+        if (_status != StepStatus.Queue)
+        {
+            throw new InvalidOperationException("The step is not in the not started status.");
+        }
+
+        return new StepRun(_step, 0, _inputs, StepStatus.MissingInput, _result, _exception);
     }
 
     public StepRun ToRunningStatus()

--- a/src/StepWise.Core/Workflow.cs
+++ b/src/StepWise.Core/Workflow.cs
@@ -63,7 +63,7 @@ public class Workflow
     /// <summary>
     /// Get all steps that depend on the given step.
     /// </summary>
-    public Step[] GetAllDependSteps(Step step)
+    public IEnumerable<Step> GetAllDependSteps(Step step)
     {
         var visited = new HashSet<string>();
         var dependSteps = new List<Step>();
@@ -89,7 +89,7 @@ public class Workflow
 
         BFS(step);
 
-        return dependSteps.Where(s => s != step).ToArray();
+        return dependSteps.Where(s => s != step);
     }
 
     /// <summary>

--- a/src/StepWise.Core/Workflow.cs
+++ b/src/StepWise.Core/Workflow.cs
@@ -92,6 +92,44 @@ public class Workflow
         return dependSteps.Where(s => s != step);
     }
 
+    public List<Step> ResolveDependencies(string targetStepName)
+    {
+        var executionPlan = new List<Step>();
+        var visited = new HashSet<string>();
+        var visiting = new HashSet<string>();
+
+        void DFS(Step step)
+        {
+            if (visited.Contains(step.Name))
+            {
+                return;
+            }
+
+            if (visiting.Contains(step.Name))
+            {
+                throw new Exception($"Circular dependency detected in step '{step.Name}'.");
+            }
+
+            visiting.Add(step.Name);
+
+            foreach (var dependency in step.Dependencies)
+            {
+                var dependencyStep = this.Steps[dependency] ?? throw new Exception($"Dependency '{dependency}' not found in the workflow.");
+                DFS(dependencyStep);
+            }
+
+            visiting.Remove(step.Name);
+            visited.Add(step.Name);
+            executionPlan.Add(step);
+        }
+
+        var targetStep = this.Steps[targetStepName] ?? throw new Exception($"Step '{targetStepName}' not found in the workflow.");
+
+        DFS(targetStep);
+
+        return executionPlan;
+    }
+
     /// <summary>
     /// Get the steps that directly depend on the given step.
     /// </summary>

--- a/src/StepWise.WebAPI/DTO.cs
+++ b/src/StepWise.WebAPI/DTO.cs
@@ -34,7 +34,7 @@ public record ExceptionDTO(string Message, string? StackTrace)
 }
 
 public record StepRunDTO(
-    StepDTO Step,
+    StepDTO? Step,
     VariableDTO[] Variables,
     int Generation,
     string Status,
@@ -46,7 +46,8 @@ public record StepRunDTO(
         var variables = stepRun.Inputs.Values.Select(VariableDTO.FromVariable).ToArray();
         var result = stepRun.Variable is null ? null : VariableDTO.FromVariable(stepRun.Variable);
         var exception = stepRun.Exception is null ? null : ExceptionDTO.FromException(stepRun.Exception);
-        return new StepRunDTO(StepDTO.FromStep(stepRun.Step), variables, stepRun.Generation, Enum.GetName(stepRun.Status)!, result, exception);
+        var stepRunDTO = stepRun.Step is null ? null : StepDTO.FromStep(stepRun.Step);
+        return new StepRunDTO(stepRunDTO, variables, stepRun.Generation, Enum.GetName(stepRun.StepType)!, result, exception);
     }
 }
 

--- a/src/StepWise.WebAPI/DTO.cs
+++ b/src/StepWise.WebAPI/DTO.cs
@@ -44,7 +44,7 @@ public record StepRunDTO(
     public static StepRunDTO FromStepRun(StepRun stepRun)
     {
         var variables = stepRun.Inputs.Values.Select(VariableDTO.FromVariable).ToArray();
-        var result = stepRun.Result is null ? null : VariableDTO.FromVariable(stepRun.Result);
+        var result = stepRun.Variable is null ? null : VariableDTO.FromVariable(stepRun.Variable);
         var exception = stepRun.Exception is null ? null : ExceptionDTO.FromException(stepRun.Exception);
         return new StepRunDTO(StepDTO.FromStep(stepRun.Step), variables, stepRun.Generation, Enum.GetName(stepRun.Status)!, result, exception);
     }

--- a/src/StepWise.WebAPI/StepWiseControllerV1.cs
+++ b/src/StepWise.WebAPI/StepWiseControllerV1.cs
@@ -75,7 +75,7 @@ public class StepWiseClient
             yield break;
         }
 
-        var engine = new StepWiseEngine(workflow, maxParallel, logger: _logger);
+        var engine = new StepWiseEngine(workflow, logger: _logger);
 
         var stopStragety = new StopStrategyPipeline();
 
@@ -96,7 +96,7 @@ public class StepWiseClient
         }
 
 
-        await foreach (var stepRunAndResult in engine.ExecuteAsync(stepName, stopStrategy: stopStragety))
+        await foreach (var stepRunAndResult in engine.ExecuteAsync(stepName, maxConcurrency: maxParallel, stopStrategy: stopStragety))
         {
             yield return stepRunAndResult;
         }

--- a/src/StepWise.WebAPI/StepWiseControllerV1.cs
+++ b/src/StepWise.WebAPI/StepWiseControllerV1.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.Logging;
 using StepWise.Core;
+using StepWise.Core.Extension;
 
 namespace StepWise.WebAPI;
 

--- a/test/StepWise.Core.Tests/GuessNumberWorkflowTest.cs
+++ b/test/StepWise.Core.Tests/GuessNumberWorkflowTest.cs
@@ -89,12 +89,12 @@ public class GuessNumberWorkflowTest
         StepVariable[] inputs = [StepVariable.Create(nameof(InputNumber), 5)];
         await foreach (var stepResult in engine.ExecuteAsync(nameof(FinalResult), inputs))
         {
-            var name = stepResult.StepName;
-            var result = stepResult.Result;
+            var name = stepResult.Name;
+            var result = stepResult.Variable;
 
-            if (result is not null)
+            if (stepResult.Status == StepStatus.Variable)
             {
-                context[name] = result;
+                context[name] = result!;
             }
 
             if (name == nameof(FinalResult) && result?.As<string>() is string finalResult)

--- a/test/StepWise.Core.Tests/GuessNumberWorkflowTest.cs
+++ b/test/StepWise.Core.Tests/GuessNumberWorkflowTest.cs
@@ -87,12 +87,12 @@ public class GuessNumberWorkflowTest
 
         var context = new Dictionary<string, StepVariable>();
         StepVariable[] inputs = [StepVariable.Create(nameof(InputNumber), 5)];
-        await foreach (var stepResult in engine.ExecuteAsync(nameof(FinalResult), inputs))
+        await foreach (var stepResult in engine.ExecuteAsync(nameof(FinalResult), inputs, stopStrategy: null))
         {
             var name = stepResult.Name;
             var result = stepResult.Variable;
 
-            if (stepResult.Status == StepStatus.Variable)
+            if (stepResult.StepType == StepType.Variable)
             {
                 context[name] = result!;
             }

--- a/test/StepWise.Core.Tests/PrepareDinnerWorkflowTest.cs
+++ b/test/StepWise.Core.Tests/PrepareDinnerWorkflowTest.cs
@@ -65,10 +65,10 @@ public class PrepareDinnerWorkflowTest
     public async Task ItPrepareDinnerConcurrentlyAsync()
     {
         var workflow = Workflow.CreateFromInstance(this);
-        var engine = new StepWiseEngine(workflow, maxConcurrency: 10);
+        var engine = new StepWiseEngine(workflow);
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        var result = await engine.ExecuteAsync<string>(nameof(ServeDinner), [StepVariable.Create(nameof(ChopVegetables), value)]);
+        var result = await engine.ExecuteAsync<string>(nameof(ServeDinner), maxConcurrency: 3, inputs: [StepVariable.Create(nameof(ChopVegetables), value)]);
 
         stopwatch.Stop();
 
@@ -82,7 +82,7 @@ public class PrepareDinnerWorkflowTest
     public async Task ItPrepareDinnerStepByStepAsync()
     {
         var workflow = Workflow.CreateFromInstance(this);
-        var engine = new StepWiseEngine(workflow, maxConcurrency: 1);
+        var engine = new StepWiseEngine(workflow);
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         var result = await engine.ExecuteAsync<string>(nameof(ServeDinner), [StepVariable.Create(nameof(ChopVegetables), new string[] { "tomato", "onion", "garlic" })]);

--- a/test/StepWise.Core.Tests/ReviewCodeWorkflow.cs
+++ b/test/StepWise.Core.Tests/ReviewCodeWorkflow.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) LittleLittleCloud. All rights reserved.
+// ReviewCodeWorkflow.cs
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Meziantou.Extensions.Logging.Xunit;
+using Microsoft.Extensions.Logging;
+using StepWise.Core.Extension;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StepWise.Core.Tests;
+
+public class ReviewCodeWorkflowTest
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+    private readonly ILogger _logger;
+
+    public ReviewCodeWorkflowTest(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+        _logger = new XUnitLoggerProvider(testOutputHelper).CreateLogger(nameof(ReviewCodeWorkflowTest));
+    }
+
+    [Step]
+    public async Task<string?> WriteCode(
+        string task,
+        [FromStep(nameof(ReviewCode))]
+        string? comment = null)
+    {
+        if (comment is not null && comment != "approve")
+        {
+            return "improved code";
+        }
+
+        if (comment == "approve")
+        {
+            return null;
+        }
+
+        return "dummy code";
+    }
+
+    [Step]
+    [DependOn(nameof(WriteCode))]
+#pragma warning disable xUnit1013 // Public method should be marked as test
+    public async Task ReviewCode([FromStep(nameof(WriteCode))] string code)
+#pragma warning restore xUnit1013 // Public method should be marked as test
+    {
+        return;
+    }
+
+    [Step]
+    [DependOn(nameof(ReviewCode))]
+    public async Task<string?> Done([FromStep(nameof(ReviewCode))] string codeComment)
+    {
+        if (codeComment != "approve")
+        {
+            return null;
+        }
+
+        return "done";
+    }
+
+    public record CodeComment(string code, string comment);
+
+    [Fact]
+    public async Task ItReviewCommentAndApproveAsync()
+    {
+        var engine = StepWiseEngine.CreateFromInstance(this, _logger);
+        var task = "dummy task";
+
+        var variables = new List<StepVariable>()
+        {
+            StepVariable.Create("task", task),
+        };
+
+        // phase 1
+        // write code
+        await foreach (var stepRun in engine.ExecuteAsync(nameof(Done), inputs: variables, stopStrategy: null))
+        {
+            if (stepRun.StepType == StepType.Variable && stepRun.Variable is not null)
+            {
+                variables.Add(stepRun.Variable);
+            }
+        }
+
+        variables.Count().Should().Be(2);
+        variables.Where(var => var.Name == nameof(WriteCode)).Should().HaveCount(1);
+
+        // phase 2
+        // review code
+        variables.Add(StepVariable.Create(nameof(ReviewCode), "improve", 2));
+
+        await foreach (var stepRun in engine.ExecuteAsync(nameof(Done), inputs: variables, stopStrategy: null))
+        {
+            if (stepRun.StepType == StepType.Variable && stepRun.Variable is not null)
+            {
+                variables.Add(stepRun.Variable);
+            }
+        }
+
+        variables.Count().Should().Be(4);
+        variables.Where(var => var.Name == nameof(WriteCode)).Should().HaveCount(2);
+
+        // phase 3
+        // approve code
+        variables.Add(StepVariable.Create(nameof(ReviewCode), "approve", 5));
+
+        await foreach (var stepRun in engine.ExecuteAsync(nameof(Done), inputs: variables, stopStrategy: null))
+        {
+            if (stepRun.StepType == StepType.Variable && stepRun.Variable is not null)
+            {
+                variables.Add(stepRun.Variable);
+            }
+        }
+
+        variables.Count().Should().Be(6);
+        variables.Where(var => var.Name == nameof(Done)).Should().HaveCount(1);
+
+        // check each variables
+        variables[0].Value.As<string>().Should().Be(task); // task
+        variables[1].Value.As<string>().Should().Be("dummy code"); // WriteCode
+        variables[2].Value.As<string>().Should().Be("improve"); // ReviewCode
+        variables[3].Value.As<string>().Should().Be("improved code"); // WriteCode
+        variables[4].Value.As<string>().Should().Be("approve"); // ReviewCode
+        variables[5].Value.As<string>().Should().Be("done"); // Done
+    }
+}

--- a/test/StepWise.Core.Tests/SelfLoopWorkflowTest.cs
+++ b/test/StepWise.Core.Tests/SelfLoopWorkflowTest.cs
@@ -77,7 +77,7 @@ public class SelfLoopWorkflowTest
         var stepRun = new List<StepRun>();
         await foreach (var stepRunAndResult in engine.ExecuteAsync(nameof(End), maxSteps: 10))
         {
-            if (stepRunAndResult.Result != null)
+            if (stepRunAndResult.Variable != null)
             {
                 stepRun.Add(stepRunAndResult);
             }
@@ -93,22 +93,22 @@ public class SelfLoopWorkflowTest
 
         stepRun.Should().HaveCount(6);
 
-        stepRun[0].StepName.Should().Be(nameof(Start));
-        stepRun[0].Result!.As<int>().Should().Be(1);
+        stepRun[0].Name.Should().Be(nameof(Start));
+        stepRun[0].Variable!.As<int>().Should().Be(1);
 
-        stepRun[1].StepName.Should().Be(nameof(AddNumberByOne));
-        stepRun[1].Result!.As<int>().Should().Be(2);
+        stepRun[1].Name.Should().Be(nameof(AddNumberByOne));
+        stepRun[1].Variable!.As<int>().Should().Be(2);
 
-        stepRun[2].StepName.Should().Be(nameof(AddNumberByOne));
-        stepRun[2].Result!.As<int>().Should().Be(3);
+        stepRun[2].Name.Should().Be(nameof(AddNumberByOne));
+        stepRun[2].Variable!.As<int>().Should().Be(3);
 
-        stepRun[3].StepName.Should().Be(nameof(AddNumberByOne));
-        stepRun[3].Result!.As<int>().Should().Be(4);
+        stepRun[3].Name.Should().Be(nameof(AddNumberByOne));
+        stepRun[3].Variable!.As<int>().Should().Be(4);
 
-        stepRun[4].StepName.Should().Be(nameof(AddNumberByOne));
-        stepRun[4].Result!.As<int>().Should().Be(5);
+        stepRun[4].Name.Should().Be(nameof(AddNumberByOne));
+        stepRun[4].Variable!.As<int>().Should().Be(5);
 
-        stepRun[5].StepName.Should().Be(nameof(End));
-        stepRun[5].Result!.As<string>().Should().Be("Done!");
+        stepRun[5].Name.Should().Be(nameof(End));
+        stepRun[5].Variable!.As<string>().Should().Be("Done!");
     }
 }

--- a/test/StepWise.Core.Tests/SelfLoopWorkflowTest.cs
+++ b/test/StepWise.Core.Tests/SelfLoopWorkflowTest.cs
@@ -72,7 +72,7 @@ public class SelfLoopWorkflowTest
         var startStep = workflow.Steps[nameof(Start)];
         var dependStartSteps = workflow.GetAllDependSteps(startStep);
         dependStartSteps.Count().Should().Be(2);
-        var engine = new StepWiseEngine(workflow, maxConcurrency: 1, _logger);
+        var engine = new StepWiseEngine(workflow, _logger);
 
         var stepRun = new List<StepRun>();
         await foreach (var stepRunAndResult in engine.ExecuteAsync(nameof(End), maxSteps: 10))

--- a/test/StepWise.Core.Tests/StepAndWorkflowTests.cs
+++ b/test/StepWise.Core.Tests/StepAndWorkflowTests.cs
@@ -116,5 +116,9 @@ public class StepAndWorkflowTests
         step.Name.Should().Be(nameof(DoNothing));
         step.InputParameters.Should().BeEmpty();
         step.OutputType.Should().Be(typeof(Task));
+
+        // invoke
+        var res = await step.ExecuteAsync();
+        res.Should().BeNull();
     }
 }


### PR DESCRIPTION
#38 

This PR implements the recovery strategy for stepwise engine.

To recover from variable group [v1, v2, v3...], A naive way is to start the stepwise engine from vanilla state, then `replay` the variable group by sending the elements one by one to step result queue.